### PR TITLE
Posible soluciones a errores de login y funciones de php-mysql obsoleta

### DIFF
--- a/BaseDatos/sp_login.sql
+++ b/BaseDatos/sp_login.sql
@@ -1,0 +1,11 @@
+USE `ccjj`;
+DROP procedure IF EXISTS `sp_login`;
+
+DELIMITER $$
+USE `ccjj`$$
+CREATE DEFINER=`root`@`localhost` PROCEDURE `sp_login`(IN `user_` VARCHAR(30), IN `pass` VARCHAR(25))
+BEGIN
+   SELECT id_Usuario,Id_Rol,esta_logueado FROM usuario WHERE nombre = user_ AND pass = udf_Decrypt_derecho(Password) AND Estado = 1;
+END$$
+
+DELIMITER ;

--- a/conexion/conn.php
+++ b/conexion/conn.php
@@ -1,6 +1,8 @@
 
 <?php
 
+error_reporting(E_ALL ^ E_DEPRECATED);
+
  $host = 'localhost';
  $dbname = 'ccjj';
  $username = 'root';


### PR DESCRIPTION
Los cambios que acaba de realizar solucionan errores que me encontre al
ejecutar el proyecto, uno de los errores que encontre es que al logearse
el archivo login_submit.php requiere del valor esta_logeado de la tabla
usuario pero que el procedimiento almacenado no devuele por lo tanto
hice un cambio al procedimiento almacenado (sp_login), tambien en mi
caso se generan errores sobre funciones de php-mysql obsoletas por eso
modifique el archivo conn.php que contiene una linea de codigo que esta
donde sé solo oculta el mensaje que es mas una advertencia que un error.
